### PR TITLE
moved length to cpu device 

### DIFF
--- a/model.py
+++ b/model.py
@@ -545,7 +545,7 @@ class LabelSmoothedCE(torch.nn.Module):
                                                batch_first=True,
                                                enforce_sorted=False)  # (sum(lengths), vocab_size)
         targets, _, _, _ = pack_padded_sequence(input=targets,
-                                                lengths=lengths,
+                                                lengths=lengths.to(device),
                                                 batch_first=True,
                                                 enforce_sorted=False)  # (sum(lengths))
 

--- a/model.py
+++ b/model.py
@@ -541,11 +541,11 @@ class LabelSmoothedCE(torch.nn.Module):
         """
         # Remove pad-positions and flatten
         inputs, _, _, _ = pack_padded_sequence(input=inputs,
-                                               lengths=lengths,
+                                               lengths=lengths.cpu(),  #"lengths" tensor is expected to be on the CPU (int64 CPU tensor), but it is currently on the GPU (cuda:0 Long tensor).
                                                batch_first=True,
                                                enforce_sorted=False)  # (sum(lengths), vocab_size)
         targets, _, _, _ = pack_padded_sequence(input=targets,
-                                                lengths=lengths.to(device),
+                                                lengths=lengths.cpu(),
                                                 batch_first=True,
                                                 enforce_sorted=False)  # (sum(lengths))
 


### PR DESCRIPTION
moved length from padded_sequence  "lengths" tensor is expected to be on the CPU (int64 CPU tensor), but it is currently on the GPU (cuda:0 Long tensor). can explicitly move the "lengths" tensor to the CPU using the .cpu() 